### PR TITLE
Set the populator pod with service account

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -718,6 +718,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 func makePopulatePodSpec(pvcPrimeName string) corev1.PodSpec {
 	return corev1.PodSpec{
+		ServiceAccountName: "forklift-controller",
 		Containers: []corev1.Container{
 			{
 				Name:            populatorContainerName,


### PR DESCRIPTION
In forklift we use the forklift-controller service account. This will let the pod the permissions to execute the migration.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>