### PR TITLE
Propogate PVC access modes

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -587,7 +587,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 						Namespace: c.populatorNamespace,
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						AccessModes:      pvc.Spec.AccessModes,
 						Resources:        pvc.Spec.Resources,
 						StorageClassName: pvc.Spec.StorageClassName,
 						VolumeMode:       pvc.Spec.VolumeMode,


### PR DESCRIPTION
When creating a PersistentVolumeClaim, propagate the accessModes. Without it, we try to use modes other than ReadWriteOnce it will stuck with improper accessMode, failing the completion of the volume populator.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>