### PR TITLE
use default ImagePullPolicy for the populator pod

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -729,7 +729,6 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:            populatorContainerName,
-				ImagePullPolicy: corev1.PullIfNotPresent,
 			},
 		},
 		RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
With the default ImagePullPolicy the image is always being pulled when the image tag is 'latest' which is very handy in test environments